### PR TITLE
upgrade graph-tools to update node-fetch to a non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cls-hooked": "^4.2.2",
     "deep-equal": "^2.0.4",
     "graphql": "^15.3.0",
-    "graphql-tools": "^6.2.4",
+    "graphql-tools": "^6.2.6",
     "jwks-rsa": "^1.10.1",
     "moment": "^2.29.1",
     "pdfkit": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,15 @@
     dataloader "2.0.0"
     tslib "~2.0.1"
 
+"@graphql-tools/batch-delegate@^6.2.6":
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-delegate/-/batch-delegate-6.2.6.tgz#fbea98dc825f87ef29ea5f3f371912c2a2aa2f2c"
+  integrity sha512-QUoE9pQtkdNPFdJHSnBhZtUfr3M7pIRoXoMR+TG7DK2Y62ISKbT/bKtZEUU1/2v5uqd5WVIvw9dF8gHDSJAsSA==
+  dependencies:
+    "@graphql-tools/delegate" "^6.2.4"
+    dataloader "2.0.0"
+    tslib "~2.0.1"
+
 "@graphql-tools/code-file-loader@^6.2.4":
   version "6.2.4"
   resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-6.2.4.tgz#ce194c19b2fcd714bffa4c0c529a4c65a6b0db4b"
@@ -5369,12 +5378,12 @@ graphql-tools@^4.0.0, graphql-tools@^4.0.8:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql-tools@^6.2.4:
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-6.2.4.tgz#e4573ab65ea53a1e64dbe1fd4ccb483b59946fd2"
-  integrity sha512-yA5E6QRz6IRZ3TrxGkh+xIGeinISZVzb3Mc0Z/3q3gu1MgqnB/3y7Iv3tXuL1DNvoNcJV5WiAU8KYMsvNSF1gQ==
+graphql-tools@^6.2.6:
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-6.2.6.tgz#557c6d32797a02988f214bd596dec2abd12425dd"
+  integrity sha512-OyhSvK5ALVVD6bFiWjAqv2+lRyvjIRfb6Br5Tkjrv++rxnXDodPH/zhMbDGRw+W3SD5ioGEEz84yO48iPiN7jA==
   dependencies:
-    "@graphql-tools/batch-delegate" "^6.2.4"
+    "@graphql-tools/batch-delegate" "^6.2.6"
     "@graphql-tools/code-file-loader" "^6.2.4"
     "@graphql-tools/delegate" "^6.2.4"
     "@graphql-tools/git-loader" "^6.2.4"


### PR DESCRIPTION
# TL;DR

Get rid of "graphql-tools@6.2.4 requires node-fetch@^1.0.1 via a transitive dependency on isomorphic-fetch@2.2.1" bug

# Proof
<img width="1426" alt="Screenshot 2021-04-05 at 6 41 29" src="https://user-images.githubusercontent.com/436605/113537847-0db05080-95da-11eb-97e4-cf49f8fbd927.png">


# Merge request checklist

Please check if your merge request fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (yarn build) was run locally and any changes were pushed
- [x] API (yarn api:dev) runs locally and any fixes were made for failures
- [x] Admin Client (cd clients/admin && yarn start) runs locally and any fixes were made for failures

# Merge request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): package upgrade

# Before this merge request
Security issue reported by dependabot.

# How you fixed what was wrong
Upgraded graph-tools to the latest 6.x version.