### PR TITLE
allow the org divider to be zero

### DIFF
--- a/apps/api/src/app/resolvers/sales.invoice.resolver.ts
+++ b/apps/api/src/app/resolvers/sales.invoice.resolver.ts
@@ -30,11 +30,7 @@ export class SalesInvoiceResolver {
 
   @Query(() => SalesInvoice)
   async salesInvoice(@Args('id', { type: () => Int }) id: number) {
-    const result = await this.salesInvoiceService.loadEntityById(
-      getManager(),
-      id,
-    );
-    return result;
+    return await this.salesInvoiceService.loadEntityById(getManager(), id);
   }
 
   @Query(() => [SalesInvoicesInTime])

--- a/apps/api/src/model/lib/sales.invoice.service.ts
+++ b/apps/api/src/model/lib/sales.invoice.service.ts
@@ -499,7 +499,7 @@ export class SalesInvoiceService extends BaseEntityService<
     const NUCZPercentage = objData.organizationDivider.find(
       x => x.id === nucz.id,
     ).value;
-    const carvagoHours = objData.totalHours;
+    const hours = objData.totalHours;
     const dailyRate = objData.dailyRate;
     const narration = objData.narration;
 
@@ -515,11 +515,8 @@ export class SalesInvoiceService extends BaseEntityService<
           {
             lineTaxIsStandard: true,
             productSku: `EX`,
-            linePrice: _.round(
-              (NUCZPercentage * carvagoHours * dailyRate) / 8,
-              2,
-            ),
-            quantity: _.round(carvagoHours * NUCZPercentage, 2),
+            linePrice: _.round((NUCZPercentage * hours * dailyRate) / 8, 2),
+            quantity: _.round(hours * NUCZPercentage, 2),
             narration,
             lineOrder: 1,
           },
@@ -544,11 +541,8 @@ export class SalesInvoiceService extends BaseEntityService<
         {
           lineTaxIsStandard: true,
           productSku: `EX`,
-          linePrice: _.round(
-            ((1 - NUCZPercentage) * carvagoHours * dailyRate) / 8,
-            2,
-          ),
-          quantity: _.round(carvagoHours * (1 - NUCZPercentage), 2),
+          linePrice: _.round(((1 - NUCZPercentage) * hours * dailyRate) / 8, 2),
+          quantity: _.round(hours * (1 - NUCZPercentage), 2),
           narration,
           lineOrder: 1,
         },

--- a/clients/admin/src/components/add-monthly-sales-invoice/AddOrEditMonthlySalesInvoice.svelte
+++ b/clients/admin/src/components/add-monthly-sales-invoice/AddOrEditMonthlySalesInvoice.svelte
@@ -12,6 +12,7 @@
     import SimpleTextBox from '../../molecules/form/SimpleTextBox.svelte';
     import { authStore } from '../../lib/auth';
     import { downloadInvoice } from '../../lib/salesInvoices';
+    import { _ } from 'svelte-i18n';
 
     const ADD_MONTHLY_SALES_INVOICE = gql`
         mutation CreateMonthlyInvoice(
@@ -120,7 +121,9 @@
     <div class="md:grid md:grid-cols-3 md:gap-6">
         <div class="md:col-span-1">
             <div class="px-4 sm:px-0">
-                <h3 class="text-lg font-medium leading-6 text-gray-900">Invoicing Information</h3>
+                <h3 class="text-lg font-medium leading-6 text-gray-900">
+                    {$_('page.salesInvoices.monthly.add.invoicingInformation')}
+                </h3>
                 <p class="mt-1 text-sm text-gray-600" />
             </div>
         </div>
@@ -129,42 +132,42 @@
                 <div class="px-4 py-5 bg-white sm:p-6">
                     <SimpleTextBox
                         form={myForm}
-                        title="Total Hours"
+                        title={$_('page.salesInvoices.monthly.add.totalHours')}
                         bind:value={totalHours}
                         id="totalHours"
                     />
 
                     <SimpleTextBox
                         form={myForm}
-                        title="Daily Rate"
+                        title={$_('page.salesInvoices.monthly.add.dailyRate')}
                         bind:value={dailyRate}
                         id="dailyRate"
                     />
 
                     <SimpleTextBox
                         form={myForm}
-                        title="NUCZ Organization Divider"
+                        title={$_('page.salesInvoices.monthly.add.orgDivider')}
                         bind:value={nuczdivider}
                         id="nuczdivider"
                     />
 
                     <SimpleTextBox
                         form={myForm}
-                        title="1 EUR = ? CZK"
+                        title={$_('page.salesInvoices.monthly.add.eur2czk')}
                         bind:value={eurToCzkRate}
                         id="eurToCzkRate"
                     />
 
                     <SimpleTextBox
                         form={myForm}
-                        title="Carvago line Narration"
+                        title={$_('page.salesInvoices.monthly.add.narration')}
                         bind:value={narration}
                         id="narration"
                     />
 
                     <SimpleTextBox
                         form={myForm}
-                        title="Invoice Date"
+                        title={$_('page.salesInvoices.monthly.add.invoiceDate')}
                         bind:value={invoiceDate}
                         id="invoiceDate"
                         type="date"
@@ -177,13 +180,15 @@
                             on:click|preventDefault={createMonthlySalesInvoice}
                             disabled={!$myForm.valid}
                         >
-                            Save
+                            {$_('page.salesInvoices.monthly.add.save')}
                         </button>
                     </div>
 
                     {#if invoiceIds}
                         <div class="bg-white px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-                            <dt class="text-sm font-medium text-gray-500">Generated invoices</dt>
+                            <dt class="text-sm font-medium text-gray-500">
+                                {$_('page.salesInvoices.monthly.add.generatedInvoices')}
+                            </dt>
                             <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
                                 <ul
                                     class="border border-gray-200 rounded-md divide-y divide-gray-200"
@@ -208,7 +213,8 @@
                                                     />
                                                 </svg>
                                                 <span class="ml-2 flex-1 w-0 truncate">
-                                                    Invoice {invoiceIds}
+                                                    {$_('page.salesInvoices.monthly.add.invoice')}
+                                                    {invoiceId}
                                                 </span>
                                             </div>
                                             <div class="ml-4 flex-shrink-0">
@@ -216,7 +222,7 @@
                                                     on:click={() => download(invoiceId)}
                                                     class="font-medium text-indigo-600 hover:text-indigo-500"
                                                 >
-                                                    Download
+                                                    {$_('page.salesInvoices.monthly.add.download')}
                                                 </a>
                                             </div>
                                         </li>

--- a/clients/admin/src/locales/en.json
+++ b/clients/admin/src/locales/en.json
@@ -35,7 +35,19 @@
       "monthly": {
         "add": {
           "title": "Add Monthly Sales Invoice",
-          "nav": "Add Monthly Sales Invoice"
+          "nav": "Add Monthly Sales Invoice",
+
+          "invoicingInformation": "Invoicing Information",
+          "totalHours": "Total Hours",
+          "dailyRate": "Daily Rate",
+          "orgDivider": "NUCZ Org Divider",
+          "eur2czk": "1 EUR = ? CZK",
+          "narration": "Main Line Narration",
+          "invoiceDate": "Invoice Date",
+          "save": "Create the Invoices",
+          "generatedInvoices": "Invoices Generated",
+          "invoice": "Invoice",
+          "download": "Download"
         }
       },
       "add": {


### PR DESCRIPTION
# TL;DR

One of the monthly invoices will be created only if the organization divider is not zero.

# Proof
![image](https://user-images.githubusercontent.com/436605/113614548-f3ff1f80-9652-11eb-9d35-f7c204dc149b.png)

# Merge request checklist

Please check if your merge request fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (yarn build) was run locally and any changes were pushed
- [x] API (`yarn api:dev`) runs locally and any fixes were made for failures
- [x] Admin Client (`cd clients/admin && yarn start`) runs locally and any fixes were made for failures

# Merge request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Before this merge request
It was not possible to set the org divider as zero.

# How you fixed what was wrong
One of the monthly invoices is created only if the org divider is not zero. I also wrote a test and while doing so I removed some code using `getService` instead of `this`. While at it I also fixed some wrong const names and added translations to the page in the Admin client.