### PR TITLE
switching to user.sub + making sure we do not fail creating user because of multiple requests

### DIFF
--- a/apps/api/src/auth/lib/authentication.service.ts
+++ b/apps/api/src/auth/lib/authentication.service.ts
@@ -61,11 +61,12 @@ export class AuthenticationService {
 
       const userService = getService<UserService>(UserServiceKey);
       const profile = {
-        user_id: response.data.email,
+        user_id: response.data.sub,
         name: response.data.preferred_username,
+        email: response.data.email,
         identities: [
           {
-            user_id: response.data.email,
+            user_id: response.data.sub,
             provider: 'keycloak',
           },
         ],

--- a/apps/api/src/model/lib/user.service.ts
+++ b/apps/api/src/model/lib/user.service.ts
@@ -8,6 +8,7 @@ import { User } from '../generated/entities/User';
 import { UserIdentity } from '../generated/entities/UserIdentity';
 import { Injectable } from '@nestjs/common';
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const AsyncLock = require('async-lock');
 const lock = new AsyncLock();
 
@@ -79,7 +80,10 @@ export class UserService
   ): Promise<UserModel> {
     const email = userProfileModel.email;
     const name = userProfileModel.name;
-    return (email && await this.findUserByEmail(manager, email)) || (name && await this.findUserByName(manager, name));
+    return (
+      (email && (await this.findUserByEmail(manager, email))) ||
+      (name && (await this.findUserByName(manager, name)))
+    );
   }
   async convertProfileIdentities(
     manager: EntityManager,
@@ -115,7 +119,7 @@ export class UserService
     try {
       await manager.save(result);
     } catch (e) {
-      console.log("Saving " + result + " failed", e);
+      console.log('Saving ' + result + ' failed', e);
     }
     const user = await this.findUser(manager, userProfileModel);
     const ident = userProfileModel.identities[0];
@@ -171,12 +175,9 @@ export class UserService
         return existingUser;
       } else {
         // this is a completely new user
-        const key= JSON.stringify(login);
+        const key = JSON.stringify(login);
         return await lock.acquire(key, () => {
           return this.createNewUser(manager, login, technicalUser);
-        }, function(err, ret) {
-          // timed out error will be returned here if lock not acquired in given time
-          console.error(err);
         });
       }
     }

--- a/apps/api/src/model/lib/user.service.ts
+++ b/apps/api/src/model/lib/user.service.ts
@@ -8,6 +8,9 @@ import { User } from '../generated/entities/User';
 import { UserIdentity } from '../generated/entities/UserIdentity';
 import { Injectable } from '@nestjs/common';
 
+const AsyncLock = require('async-lock');
+const lock = new AsyncLock();
+
 export const UserServiceKey = 'UserService';
 
 export interface LoginHandler {
@@ -50,6 +53,13 @@ export class UserService
       .findOne({ where: { email } });
     return found || null;
   }
+  async findUserByName(manager: EntityManager, name: string): Promise<User> {
+    if (!name) return null;
+    const found = await manager
+      .getRepository(User)
+      .findOne({ where: { name } });
+    return found || null;
+  }
 
   async findUserIdentity(
     manager: EntityManager,
@@ -68,7 +78,8 @@ export class UserService
     userProfileModel: UserProfileModel,
   ): Promise<UserModel> {
     const email = userProfileModel.email;
-    return await this.findUserByEmail(manager, email);
+    const name = userProfileModel.name;
+    return (email && await this.findUserByEmail(manager, email)) || (name && await this.findUserByName(manager, name));
   }
   async convertProfileIdentities(
     manager: EntityManager,
@@ -99,15 +110,20 @@ export class UserService
   ): Promise<User> {
     const result = new User();
     result.email = userProfileModel.email;
-    result.name = userProfileModel.name;
+    result.name = userProfileModel.name || userProfileModel.email;
     result.updtOpId = technicalUser.id;
-    await manager.save(result);
+    try {
+      await manager.save(result);
+    } catch (e) {
+      console.log("Saving " + result + " failed", e);
+    }
+    const user = await this.findUser(manager, userProfileModel);
     const ident = userProfileModel.identities[0];
     const userIdentity = new UserIdentity();
     userIdentity.externalUser = ident.user_id;
     userIdentity.provider = ident.provider;
-    userIdentity.user = result;
-    userIdentity.updtOp = result;
+    userIdentity.user = user;
+    userIdentity.updtOp = user;
     await manager.save(userIdentity);
     result.identities = [userIdentity];
     return result;
@@ -155,7 +171,13 @@ export class UserService
         return existingUser;
       } else {
         // this is a completely new user
-        return await this.createNewUser(manager, login, technicalUser);
+        const key= JSON.stringify(login);
+        return await lock.acquire(key, () => {
+          return this.createNewUser(manager, login, technicalUser);
+        }, function(err, ret) {
+          // timed out error will be returned here if lock not acquired in given time
+          console.error(err);
+        });
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
+        "@types/async-lock": "^1.4.2",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
         "@types/multer": "^1.4.11",
@@ -2561,6 +2562,12 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "devOptional": true
+    },
+    "node_modules/@types/async-lock": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/graphql": "^12.0.11",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.1",
+        "async-lock": "^1.4.1",
         "aws-sdk": "^2.1515.0",
         "axios": "^1.6.2",
         "azure-storage": "^2.10.7",
@@ -3528,6 +3529,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
       "optional": true
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
     },
     "node_modules/async-retry": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nestjs/graphql": "^12.0.11",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.1",
+    "async-lock": "^1.4.1",
     "aws-sdk": "^2.1515.0",
     "axios": "^1.6.2",
     "azure-storage": "^2.10.7",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/async-lock": "^1.4.2",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/multer": "^1.4.11",


### PR DESCRIPTION
# TL;DR

There was an annoying bug when users would fail to log in just after they were created. Also, we always required users to have an email.

# Proof
Just try.

# Merge request checklist

Please check if your merge request fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes/features)
- [x] Build (`yarn build`) was run locally and any changes were pushed for both API and clients
- [x] API (`yarn api:dev`) runs locally and any fixes were made for failures
- [x] Admin Client (`cd clients/admin && yarn start`) runs locally and any fixes were made for failures

# Merge request type

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no APIoduce  changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Before this merge request
The requests were coming at the same time and since the code is async, the commit would fail.

# How you fixed what was wrong
Start using sub instead of email (that allows users without emails to get in).
Added a lock to allow user creation to finish.

